### PR TITLE
Protability fixes onto the musl C library

### DIFF
--- a/kms++util/inc/kms++util/kms++util.h
+++ b/kms++util/inc/kms++util/kms++util.h
@@ -35,6 +35,13 @@ Connector* resolve_connector(Card& card, const std::string& str);
 
 #define unlikely(x) __builtin_expect(!!(x), 0)
 
+/* __STRING(x) is a glibcism (i.e. not standard), which happens to also
+ * be available in uClibc. However, musl does not define it. Do it here.
+ */
+#ifndef __STRING
+#define __STRING(x) #x
+#endif
+
 #define ASSERT(x) \
 	if (unlikely(!(x))) { \
 		fprintf(stderr, "%s:%d: %s: ASSERT(%s) failed\n", __FILE__, __LINE__, __PRETTY_FUNCTION__, __STRING(x)); \

--- a/utils/testpat.cpp
+++ b/utils/testpat.cpp
@@ -5,6 +5,8 @@
 #include <set>
 #include <chrono>
 
+#include <sys/select.h>
+
 #include <kms++/kms++.h>
 #include <kms++/modedb.h>
 


### PR DESCRIPTION
Hello!

The musl C library is more conservative in what it defines and how it
includes its own headers, limiting itself to strict standard-compliance,
with the occasional glibc-compatibility stuff.

Those two patches fixes two partability issues with musl.

Fixes build issues noticed with the Buildroot autobuilders, e.g.:
    http://autobuild.buildroot.net/results/682/68266cb5b26a62387dc99aef31fc9654c8fcd505/

Regards,
Yann E. MORIN.
