### PR TITLE
Add BGR888 (BG24) and BGR565 (BG16) pixelformats.

### DIFF
--- a/kms++/inc/kms++/pixelformats.h
+++ b/kms++/inc/kms++/pixelformats.h
@@ -28,8 +28,10 @@ enum class PixelFormat : uint32_t
 	ABGR8888 = MakeFourCC("AB24"),
 
 	RGB888 = MakeFourCC("RG24"),
+	BGR888 = MakeFourCC("BG24"),
 
 	RGB565 = MakeFourCC("RG16"),
+	BGR565 = MakeFourCC("BG16"),
 };
 
 static inline PixelFormat FourCCToPixelFormat(const std::string& fourcc)

--- a/kms++/src/pixelformats.cpp
+++ b/kms++/src/pixelformats.cpp
@@ -17,8 +17,10 @@ static const map<PixelFormat, PixelFormatInfo> format_info_array = {
 	{ PixelFormat::NV21, { 2, { { 8, 1, 1, }, { 8, 2, 2 } }, } },
 	/* RGB16 */
 	{ PixelFormat::RGB565, { 1, { { 16, 1, 1 } }, } },
+	{ PixelFormat::BGR565, { 1, { { 16, 1, 1 } }, } },
 	/* RGB24 */
 	{ PixelFormat::RGB888, { 1, { { 24, 1, 1 } }, } },
+	{ PixelFormat::BGR888, { 1, { { 24, 1, 1 } }, } },
 	/* RGB32 */
 	{ PixelFormat::XRGB8888, { 1, { { 32, 1, 1 } }, } },
 	{ PixelFormat::XBGR8888, { 1, { { 32, 1, 1 } }, } },

--- a/kms++util/inc/kms++util/color.h
+++ b/kms++util/inc/kms++util/color.h
@@ -14,9 +14,11 @@ struct RGB
 	RGB(uint32_t argb);
 
 	uint32_t rgb888() const;
+	uint32_t bgr888() const;
 	uint32_t argb8888() const;
 	uint32_t abgr8888() const;
 	uint16_t rgb565() const;
+	uint16_t bgr565() const;
 	YUV yuv() const;
 
 	uint8_t b;

--- a/kms++util/src/color.cpp
+++ b/kms++util/src/color.cpp
@@ -34,6 +34,11 @@ uint32_t RGB::rgb888() const
 	return (r << 16) | (g << 8) | (b << 0);
 }
 
+uint32_t RGB::bgr888() const
+{
+	return (b << 16) | (g << 8) | (r << 0);
+}
+
 uint32_t RGB::argb8888() const
 {
 	return (a << 24) | (r << 16) | (g << 8) | (b << 0);
@@ -47,6 +52,11 @@ uint32_t RGB::abgr8888() const
 uint16_t RGB::rgb565() const
 {
 	return ((r >> 3) << 11) | ((g >> 2) << 5) | ((b >> 3) << 0);
+}
+
+uint16_t RGB::bgr565() const
+{
+	return ((b >> 3) << 11) | ((g >> 2) << 5) | ((r >> 3) << 0);
 }
 
 YUV RGB::yuv() const

--- a/kms++util/src/colorbar.cpp
+++ b/kms++util/src/colorbar.cpp
@@ -116,6 +116,11 @@ void draw_color_bar(IMappedFramebuffer& buf, int old_xpos, int xpos, int width)
 		drm_draw_color_bar_rgb565(buf, old_xpos, xpos, width);
 		break;
 
+	case PixelFormat::BGR565:
+		// XXX not right, red and blue are reversed
+		drm_draw_color_bar_rgb565(buf, old_xpos, xpos, width);
+		break;
+
 	case PixelFormat::XRGB8888:
 		drm_draw_color_bar_rgb888(buf, old_xpos, xpos, width);
 		break;

--- a/kms++util/src/drawing.cpp
+++ b/kms++util/src/drawing.cpp
@@ -31,10 +31,24 @@ void draw_rgb_pixel(IMappedFramebuffer& buf, unsigned x, unsigned y, RGB color)
 		p[2] = color.b;
 		break;
 	}
+	case PixelFormat::BGR888:
+	{
+		uint8_t *p = buf.map(0) + buf.stride(0) * y + x * 3;
+		p[0] = color.b;
+		p[1] = color.g;
+		p[2] = color.r;
+		break;
+	}
 	case PixelFormat::RGB565:
 	{
 		uint16_t *p = (uint16_t*)(buf.map(0) + buf.stride(0) * y + x * 2);
 		*p = color.rgb565();
+		break;
+	}
+	case PixelFormat::BGR565:
+	{
+		uint16_t *p = (uint16_t*)(buf.map(0) + buf.stride(0) * y + x * 2);
+		*p = color.bgr565();
 		break;
 	}
 	default:
@@ -159,7 +173,9 @@ static void draw_char(IMappedFramebuffer& buf, uint32_t xpos, uint32_t ypos, cha
 	case PixelFormat::ARGB8888:
 	case PixelFormat::ABGR8888:
 	case PixelFormat::RGB888:
+	case PixelFormat::BGR888:
 	case PixelFormat::RGB565:
+	case PixelFormat::BGR565:
 		for (y = 0; y < 8; y++) {
 			for (x = 0; x < 8; x++) {
 				bool b = get_char_pixel(c, x, y);


### PR DESCRIPTION
Note colorbar does not support 24 bit modes (RGB888 or BGR888) yet.