### PR TITLE
ExtFramebuffer cleanup

### DIFF
--- a/kms++/src/extframebuffer.cpp
+++ b/kms++/src/extframebuffer.cpp
@@ -87,6 +87,10 @@ ExtFramebuffer::~ExtFramebuffer()
 	for (unsigned i = 0; i < m_num_planes; ++i) {
 		FramebufferPlane& plane = m_planes[i];
 
+		/* unmap buffer */
+		if (plane.map)
+			munmap(plane.map, plane.size);
+
 		if (plane.prime_fd && plane.handle) {
 			drm_gem_close closeReq {};
 			int ret;


### PR DESCRIPTION
Hi,
please consider the below patches which add some more cleanup for ExtFramebuffer.
Without this patches you can get out of memory in use-cases which allocate/release
lots of PRIME buffers.

Thank you,
Oleksandr Andrushchenko