### PR TITLE
add android port

### DIFF
--- a/kms++/Android.mk
+++ b/kms++/Android.mk
@@ -1,0 +1,30 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := libkms++
+LOCAL_MODULE_TAGS := optional
+
+LOCAL_SRC_FILES := \
+    $(patsubst $(LOCAL_PATH)/%,%, \
+      $(wildcard $(LOCAL_PATH)/src/*.cpp)) \
+    $(empty)
+
+LOCAL_RTTI_FLAG := -frtti
+LOCAL_CPPFLAGS := \
+    -std=c++11 \
+    -fexceptions \
+    -Wextra \
+    -Wno-unused-parameter \
+    $(empty)
+
+LOCAL_C_INCLUDES := \
+    external/libdrm/include/drm \
+    $(LOCAL_PATH)/inc \
+    $(empty)
+
+LOCAL_SHARED_LIBRARIES := \
+    libdrm \
+    $(empty)
+
+include $(BUILD_SHARED_LIBRARY)

--- a/kms++/src/card.cpp
+++ b/kms++/src/card.cpp
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <cstdlib>
+#include <cerrno>
 #include <utility>
 #include <stdexcept>
 #include <string.h>

--- a/kms++/src/dumbframebuffer.cpp
+++ b/kms++/src/dumbframebuffer.cpp
@@ -1,4 +1,5 @@
 
+#include <cerrno>
 #include <cstring>
 #include <stdexcept>
 #include <sys/mman.h>

--- a/kms++/src/extframebuffer.cpp
+++ b/kms++/src/extframebuffer.cpp
@@ -1,5 +1,6 @@
 
 #include <cstring>
+#include <cerrno>
 #include <stdexcept>
 #include <sys/mman.h>
 #include <xf86drm.h>

--- a/kms++util/Android.mk
+++ b/kms++util/Android.mk
@@ -1,0 +1,30 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := libkms++util
+LOCAL_MODULE_TAGS := optional
+
+LOCAL_SRC_FILES := \
+    $(patsubst $(LOCAL_PATH)/%,%, \
+      $(wildcard $(LOCAL_PATH)/src/*.cpp)) \
+    $(empty)
+
+LOCAL_RTTI_FLAG := -frtti
+LOCAL_CPPFLAGS := \
+    -std=c++11 \
+    -fexceptions \
+    -Wextra \
+    -Wno-unused-parameter \
+    $(empty)
+
+LOCAL_C_INCLUDES := \
+    $(LOCAL_PATH)/inc \
+    $(dir $(LOCAL_PATH))/kms++/inc \
+    $(empty)
+
+LOCAL_SHARED_LIBRARIES := \
+    libkms++ \
+    $(empty)
+
+include $(BUILD_SHARED_LIBRARY)

--- a/utils/Android.mk
+++ b/utils/Android.mk
@@ -1,0 +1,41 @@
+LOCAL_PATH := $(call my-dir)
+
+.PHONY: kms++-targets
+
+define kms++-define-executable
+include $$(CLEAR_VARS)
+LOCAL_MODULE := $(1)
+LOCAL_MODULE_TAGS := optional
+LOCAL_SRC_FILES := $(1).cpp
+LOCAL_RTTI_FLAG := -frtti
+LOCAL_CPPFLAGS := \
+    -std=c++11 \
+    -fexceptions \
+    -Wextra \
+    -Wno-unused-parameter \
+    $(empty)
+LOCAL_C_INCLUDES := $(2)
+LOCAL_SHARED_LIBRARIES := $(3)
+include $$(BUILD_EXECUTABLE)
+
+kms++-targets: $(1)
+
+endef
+
+# kmscapture depends on glob.h that may not be available in Bionic libc.
+KSMPP_UTILS := kmstest kmsview kmsprint kmsblank wbcap wbm2m
+ifneq ($(strip $(wildcard bionic/libc/include/glob.h)),)
+KSMPP_UTILS += kmscapture
+endif
+$(foreach m,$(KSMPP_UTILS), \
+  $(eval $(call kms++-define-executable,$(m), \
+    external/libdrm/include/drm \
+    $(addprefix $(dir $(LOCAL_PATH))/,kms++/inc kms++util/inc) \
+    , \
+    libdrm libkms++ libkms++util)))
+
+KSMPP_UTILS += fbtest
+$(eval $(call kms++-define-executable,fbtest, \
+    $(addprefix $(dir $(LOCAL_PATH))/,kms++/inc kms++util/inc) \
+    , \
+    libkms++ libkms++util))


### PR DESCRIPTION
Builds on Android Nougat or newer. For older releases, it fails due to the lack of recent libdrm APIs, e.g. **drmModeAtomicCommit()**.