### PR TITLE
Allow making extframebuffer and dmabufframebuffer with modifiers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ if (NOT ${U_CMAKE_BUILD_TYPE} MATCHES DEBUG)
 endif()
 
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(LIBDRM libdrm>=2.4.64 REQUIRED)
+pkg_check_modules(LIBDRM libdrm>=2.4.71 REQUIRED)
 
 pkg_check_modules(LIBDRM_OMAP libdrm_omap)
 if(LIBDRM_OMAP_FOUND)

--- a/kms++/inc/kms++/dmabufframebuffer.h
+++ b/kms++/inc/kms++/dmabufframebuffer.h
@@ -20,10 +20,10 @@ public:
 	PixelFormat format() const override { return m_format; }
 	unsigned num_planes() const override { return m_num_planes; }
 
-	uint32_t handle(unsigned plane) const { return m_planes[plane].handle; }
-	uint32_t stride(unsigned plane) const override { return m_planes[plane].stride; }
-	uint32_t size(unsigned plane) const override { return m_planes[plane].size; }
-	uint32_t offset(unsigned plane) const override { return m_planes[plane].offset; }
+	uint32_t handle(unsigned plane) const { return m_planes.at(plane).handle; }
+	uint32_t stride(unsigned plane) const override { return m_planes.at(plane).stride; }
+	uint32_t size(unsigned plane) const override { return m_planes.at(plane).size; }
+	uint32_t offset(unsigned plane) const override { return m_planes.at(plane).offset; }
 	uint8_t* map(unsigned plane) override;
 	int prime_fd(unsigned plane) override;
 
@@ -41,7 +41,7 @@ private:
 	};
 
 	unsigned m_num_planes;
-	struct FramebufferPlane m_planes[4];
+	std::array<FramebufferPlane, 4> m_planes;
 
 	PixelFormat m_format;
 

--- a/kms++/inc/kms++/dmabufframebuffer.h
+++ b/kms++/inc/kms++/dmabufframebuffer.h
@@ -11,7 +11,7 @@ class DmabufFramebuffer : public Framebuffer
 {
 public:
 	DmabufFramebuffer(Card& card, uint32_t width, uint32_t height, PixelFormat format,
-			  std::vector<int> fds, std::vector<uint32_t> pitches, std::vector<uint32_t> offsets);
+			  std::vector<int> fds, std::vector<uint32_t> pitches, std::vector<uint32_t> offsets, std::vector<uint64_t> modifiers = {});
 	~DmabufFramebuffer() override;
 
 	uint32_t width() const override { return Framebuffer::width(); }
@@ -37,6 +37,7 @@ private:
 		uint32_t size;
 		uint32_t stride;
 		uint32_t offset;
+		uint64_t modifier;
 		uint8_t *map;
 	};
 

--- a/kms++/inc/kms++/dumbframebuffer.h
+++ b/kms++/inc/kms++/dumbframebuffer.h
@@ -19,10 +19,10 @@ public:
 	PixelFormat format() const override { return m_format; }
 	unsigned num_planes() const override { return m_num_planes; }
 
-	uint32_t handle(unsigned plane) const { return m_planes[plane].handle; }
-	uint32_t stride(unsigned plane) const override { return m_planes[plane].stride; }
-	uint32_t size(unsigned plane) const override { return m_planes[plane].size; }
-	uint32_t offset(unsigned plane) const override { return m_planes[plane].offset; }
+	uint32_t handle(unsigned plane) const { return m_planes.at(plane).handle; }
+	uint32_t stride(unsigned plane) const override { return m_planes.at(plane).stride; }
+	uint32_t size(unsigned plane) const override { return m_planes.at(plane).size; }
+	uint32_t offset(unsigned plane) const override { return m_planes.at(plane).offset; }
 	uint8_t* map(unsigned plane) override;
 	int prime_fd(unsigned plane) override;
 
@@ -37,7 +37,7 @@ private:
 	};
 
 	unsigned m_num_planes;
-	struct FramebufferPlane m_planes[4];
+	std::array<FramebufferPlane, 4> m_planes;
 
 	PixelFormat m_format;
 };

--- a/kms++/inc/kms++/extframebuffer.h
+++ b/kms++/inc/kms++/extframebuffer.h
@@ -20,10 +20,10 @@ public:
 	PixelFormat format() const override { return m_format; }
 	unsigned num_planes() const override { return m_num_planes; }
 
-	uint32_t handle(unsigned plane) const { return m_planes[plane].handle; }
-	uint32_t stride(unsigned plane) const override { return m_planes[plane].stride; }
-	uint32_t size(unsigned plane) const override { return m_planes[plane].size; }
-	uint32_t offset(unsigned plane) const override { return m_planes[plane].offset; }
+	uint32_t handle(unsigned plane) const { return m_planes.at(plane).handle; }
+	uint32_t stride(unsigned plane) const override { return m_planes.at(plane).stride; }
+	uint32_t size(unsigned plane) const override { return m_planes.at(plane).size; }
+	uint32_t offset(unsigned plane) const override { return m_planes.at(plane).offset; }
 
 private:
 	struct FramebufferPlane {
@@ -35,7 +35,7 @@ private:
 	};
 
 	unsigned m_num_planes;
-	struct FramebufferPlane m_planes[4];
+	std::array<FramebufferPlane, 4> m_planes;
 
 	PixelFormat m_format;
 };

--- a/kms++/inc/kms++/extframebuffer.h
+++ b/kms++/inc/kms++/extframebuffer.h
@@ -11,7 +11,7 @@ class ExtFramebuffer : public Framebuffer
 {
 public:
 	ExtFramebuffer(Card& card, uint32_t width, uint32_t height, PixelFormat format,
-		       std::vector<uint32_t> handles, std::vector<uint32_t> pitches, std::vector<uint32_t> offsets);
+		       std::vector<uint32_t> handles, std::vector<uint32_t> pitches, std::vector<uint32_t> offsets, std::vector<uint64_t> modifiers = {});
 	~ExtFramebuffer() override;
 
 	uint32_t width() const override { return Framebuffer::width(); }
@@ -31,6 +31,7 @@ private:
 		uint32_t size;
 		uint32_t stride;
 		uint32_t offset;
+		uint64_t modifier;
 		uint8_t *map;
 	};
 

--- a/kms++/src/dmabufframebuffer.cpp
+++ b/kms++/src/dmabufframebuffer.cpp
@@ -32,7 +32,7 @@ DmabufFramebuffer::DmabufFramebuffer(Card& card, uint32_t width, uint32_t height
 		throw std::invalid_argument("the size of fds, pitches and offsets has to match number of planes");
 
 	for (int i = 0; i < format_info.num_planes; ++i) {
-		FramebufferPlane& plane = m_planes[i];
+		FramebufferPlane& plane = m_planes.at(i);
 
 		plane.prime_fd = fds[i];
 
@@ -65,7 +65,7 @@ DmabufFramebuffer::~DmabufFramebuffer()
 
 uint8_t* DmabufFramebuffer::map(unsigned plane)
 {
-	FramebufferPlane& p = m_planes[plane];
+	FramebufferPlane& p = m_planes.at(plane);
 
 	if (p.map)
 		return p.map;
@@ -80,7 +80,7 @@ uint8_t* DmabufFramebuffer::map(unsigned plane)
 
 int DmabufFramebuffer::prime_fd(unsigned plane)
 {
-	FramebufferPlane& p = m_planes[plane];
+	FramebufferPlane& p = m_planes.at(plane);
 
 	return p.prime_fd;
 }

--- a/kms++/src/dmabufframebuffer.cpp
+++ b/kms++/src/dmabufframebuffer.cpp
@@ -28,6 +28,9 @@ DmabufFramebuffer::DmabufFramebuffer(Card& card, uint32_t width, uint32_t height
 
 	m_num_planes = format_info.num_planes;
 
+	if (fds.size() != m_num_planes || pitches.size() != m_num_planes || offsets.size() != m_num_planes)
+		throw std::invalid_argument("the size of fds, pitches and offsets has to match number of planes");
+
 	for (int i = 0; i < format_info.num_planes; ++i) {
 		FramebufferPlane& plane = m_planes[i];
 
@@ -45,6 +48,8 @@ DmabufFramebuffer::DmabufFramebuffer(Card& card, uint32_t width, uint32_t height
 
 	uint32_t id;
 	uint32_t bo_handles[4] = { m_planes[0].handle, m_planes[1].handle, m_planes[2].handle, m_planes[3].handle };
+	pitches.resize(4);
+	offsets.resize(4);
 	r = drmModeAddFB2(card.fd(), width, height, (uint32_t)format,
 			  bo_handles, pitches.data(), offsets.data(), &id, 0);
 	if (r)

--- a/kms++/src/dumbframebuffer.cpp
+++ b/kms++/src/dumbframebuffer.cpp
@@ -36,7 +36,7 @@ DumbFramebuffer::DumbFramebuffer(Card& card, uint32_t width, uint32_t height, Pi
 
 	for (int i = 0; i < format_info.num_planes; ++i) {
 		const PixelFormatPlaneInfo& pi = format_info.planes[i];
-		FramebufferPlane& plane = m_planes[i];
+		FramebufferPlane& plane = m_planes.at(i);
 
 		/* create dumb buffer */
 		struct drm_mode_create_dumb creq = drm_mode_create_dumb();
@@ -74,7 +74,7 @@ DumbFramebuffer::~DumbFramebuffer()
 	drmModeRmFB(card().fd(), id());
 
 	for (uint i = 0; i < m_num_planes; ++i) {
-		FramebufferPlane& plane = m_planes[i];
+		FramebufferPlane& plane = m_planes.at(i);
 
 		/* unmap buffer */
 		if (plane.map)
@@ -91,7 +91,7 @@ DumbFramebuffer::~DumbFramebuffer()
 
 uint8_t* DumbFramebuffer::map(unsigned plane)
 {
-	FramebufferPlane& p = m_planes[plane];
+	FramebufferPlane& p = m_planes.at(plane);
 
 	if (p.map)
 		return p.map;
@@ -114,15 +114,15 @@ uint8_t* DumbFramebuffer::map(unsigned plane)
 
 int DumbFramebuffer::prime_fd(unsigned int plane)
 {
-	if (m_planes[plane].prime_fd >= 0)
-		return m_planes[plane].prime_fd;
+	if (m_planes.at(plane).prime_fd >= 0)
+		return m_planes.at(plane).prime_fd;
 
-	int r = drmPrimeHandleToFD(card().fd(), m_planes[plane].handle,
-				   DRM_CLOEXEC | O_RDWR, &m_planes[plane].prime_fd);
+	int r = drmPrimeHandleToFD(card().fd(), m_planes.at(plane).handle,
+				   DRM_CLOEXEC | O_RDWR, &m_planes.at(plane).prime_fd);
 	if (r)
 		throw std::runtime_error("drmPrimeHandleToFD failed");
 
-	return m_planes[plane].prime_fd;
+	return m_planes.at(plane).prime_fd;
 }
 
 }

--- a/kms++/src/extframebuffer.cpp
+++ b/kms++/src/extframebuffer.cpp
@@ -15,7 +15,7 @@ namespace kms
 {
 
 ExtFramebuffer::ExtFramebuffer(Card& card, uint32_t width, uint32_t height, PixelFormat format,
-			       vector<uint32_t> handles, vector<uint32_t> pitches, vector<uint32_t> offsets)
+			       vector<uint32_t> handles, vector<uint32_t> pitches, vector<uint32_t> offsets, vector<uint64_t> modifiers)
 	: Framebuffer(card, width, height)
 {
 	m_format = format;
@@ -33,6 +33,7 @@ ExtFramebuffer::ExtFramebuffer(Card& card, uint32_t width, uint32_t height, Pixe
 		plane.handle = handles[i];
 		plane.stride = pitches[i];
 		plane.offset = offsets[i];
+		plane.modifier = modifiers.empty() ? 0 : modifiers[i];
 		plane.size = plane.stride * height;
 		plane.map = 0;
 	}
@@ -41,7 +42,16 @@ ExtFramebuffer::ExtFramebuffer(Card& card, uint32_t width, uint32_t height, Pixe
 	handles.resize(4);
 	pitches.resize(4);
 	offsets.resize(4);
-	int r = drmModeAddFB2(card.fd(), width, height, (uint32_t)format, handles.data(), pitches.data(), offsets.data(), &id, 0);
+	int r;
+
+	if (modifiers.empty()) {
+		r = drmModeAddFB2(card.fd(), width, height, (uint32_t)format, handles.data(), pitches.data(), offsets.data(), &id, 0);
+	}
+	else {
+		modifiers.resize(4);
+		r = drmModeAddFB2WithModifiers(card.fd(), width, height, (uint32_t)format, handles.data(), pitches.data(), offsets.data(), modifiers.data(), &id, DRM_MODE_FB_MODIFIERS);
+	}
+
 	if (r)
 		throw std::invalid_argument(string("Failed to create ExtFramebuffer: ") + strerror(r));
 

--- a/kms++/src/extframebuffer.cpp
+++ b/kms++/src/extframebuffer.cpp
@@ -28,10 +28,9 @@ ExtFramebuffer::ExtFramebuffer(Card& card, uint32_t width, uint32_t height, Pixe
 		throw std::invalid_argument("the size of handles, pitches and offsets has to match number of planes");
 
 	for (int i = 0; i < format_info.num_planes; ++i) {
-		FramebufferPlane& plane = m_planes[i];
+		FramebufferPlane& plane = m_planes.at(i);
 
 		plane.handle = handles[i];
-
 		plane.stride = pitches[i];
 		plane.offset = offsets[i];
 		plane.size = plane.stride * height;

--- a/kms++/src/extframebuffer.cpp
+++ b/kms++/src/extframebuffer.cpp
@@ -24,6 +24,9 @@ ExtFramebuffer::ExtFramebuffer(Card& card, uint32_t width, uint32_t height, Pixe
 
 	m_num_planes = format_info.num_planes;
 
+	if (handles.size() != m_num_planes || pitches.size() != m_num_planes || offsets.size() != m_num_planes)
+		throw std::invalid_argument("the size of handles, pitches and offsets has to match number of planes");
+
 	for (int i = 0; i < format_info.num_planes; ++i) {
 		FramebufferPlane& plane = m_planes[i];
 
@@ -36,6 +39,9 @@ ExtFramebuffer::ExtFramebuffer(Card& card, uint32_t width, uint32_t height, Pixe
 	}
 
 	uint32_t id;
+	handles.resize(4);
+	pitches.resize(4);
+	offsets.resize(4);
 	int r = drmModeAddFB2(card.fd(), width, height, (uint32_t)format, handles.data(), pitches.data(), offsets.data(), &id, 0);
 	if (r)
 		throw std::invalid_argument(string("Failed to create ExtFramebuffer: ") + strerror(r));


### PR DESCRIPTION
Many GPUs use bandwidth compression or tiling, and this information
must be passed along to KMS when constructing the framebuffer object
around the GEM handle or prime filedescriptor.

Add an overload of these two framebuffer classes' constructors to
allow that.

Signed-off-by: Matt Hoosier <matt.hoosier@garmin.com>