### PR TITLE
Set a dummy version number on the shared libraries

### DIFF
--- a/kms++/CMakeLists.txt
+++ b/kms++/CMakeLists.txt
@@ -24,8 +24,11 @@ target_include_directories(kms++ PUBLIC
 
 target_link_libraries(kms++ ${LIBDRM_LIBRARIES} ${LIBDRM_OMAP_LIBRARIES} fmt::fmt)
 
+# Set a dummy SOVERSION just to avoid having a naked .so file in the filesystem.
+# This version number doesn't make any promise about API/ABI stability.
 set_target_properties(kms++ PROPERTIES
-    PUBLIC_HEADER "${PUB_HDRS}")
+    PUBLIC_HEADER "${PUB_HDRS}"
+    SOVERSION 0)
 
 install(TARGETS kms++
     LIBRARY DESTINATION lib

--- a/kms++util/CMakeLists.txt
+++ b/kms++util/CMakeLists.txt
@@ -14,8 +14,11 @@ if (KMSXX_ENABLE_THREADING)
     add_definitions(-DHAS_PTHREAD)
 endif()
 
+# Set a dummy SOVERSION just to avoid havig a naked .so file in the filesystem.
+# This version number doesn't make any promise about API/ABI stability.
 set_target_properties(kms++util PROPERTIES
-    PUBLIC_HEADER "${PUB_HDRS}")
+    PUBLIC_HEADER "${PUB_HDRS}"
+    SOVERSION 0)
 
 install(TARGETS kms++util
     LIBRARY DESTINATION lib


### PR DESCRIPTION
This makes package managers happier when the software is built
as a dynamic-library.

Signed-off-by: Matt Hoosier <matt.hoosier@garmin.com>