### PR TITLE
resmgr: add release() methods

### DIFF
--- a/kms++util/inc/kms++util/resourcemanager.h
+++ b/kms++util/inc/kms++util/resourcemanager.h
@@ -14,13 +14,16 @@ public:
 	Card& card() const { return m_card; }
 	Connector* reserve_connector(const std::string& name = "");
 	Connector* reserve_connector(Connector* conn);
+	void release_connector(Connector* conn);
 	Crtc* reserve_crtc(Connector* conn);
 	Crtc* reserve_crtc(Crtc* crtc);
+	void release_crtc(Crtc* crtc);
 	Plane* reserve_plane(Crtc* crtc, PlaneType type, PixelFormat format = PixelFormat::Undefined);
 	Plane* reserve_plane(Plane* plane);
 	Plane* reserve_generic_plane(Crtc* crtc, PixelFormat format = PixelFormat::Undefined);
 	Plane* reserve_primary_plane(Crtc* crtc, PixelFormat format = PixelFormat::Undefined);
 	Plane* reserve_overlay_plane(Crtc* crtc, PixelFormat format = PixelFormat::Undefined);
+	void release_plane(Plane* plane);
 
 private:
 	Card& m_card;

--- a/kms++util/src/resourcemanager.cpp
+++ b/kms++util/src/resourcemanager.cpp
@@ -104,6 +104,11 @@ Connector* ResourceManager::reserve_connector(Connector* conn)
 	return conn;
 }
 
+void ResourceManager::release_connector(Connector* conn)
+{
+	m_reserved_connectors.erase(conn);
+}
+
 Crtc* ResourceManager::reserve_crtc(Connector* conn)
 {
 	if (!conn)
@@ -136,6 +141,11 @@ Crtc* ResourceManager::reserve_crtc(Crtc* crtc)
 	m_reserved_crtcs.insert(crtc);
 
 	return crtc;
+}
+
+void ResourceManager::release_crtc(Crtc* crtc)
+{
+	m_reserved_crtcs.erase(crtc);
 }
 
 Plane* ResourceManager::reserve_plane(Crtc* crtc, PlaneType type, PixelFormat format)
@@ -203,4 +213,9 @@ Plane* ResourceManager::reserve_primary_plane(Crtc* crtc, PixelFormat format)
 Plane* ResourceManager::reserve_overlay_plane(Crtc* crtc, PixelFormat format)
 {
 	return reserve_plane(crtc, PlaneType::Overlay, format);
+}
+
+void ResourceManager::release_plane(Plane* plane)
+{
+	m_reserved_planes.erase(plane);
 }


### PR DESCRIPTION
This makes the ResourceManager class much more functional
for uses where the set of resources used to scan out a
scene changes from frame to frame. The atomic modesetting
API discipline requires a brute-force search to find a
compatible pairing of planes/etc, and being able to reserve
bits incrementally is much simpler than throwing out the
entire resourcemanager and make a new one each time a
resource reserved in a tentative attempt to probe its
compatibility with an test-mode atomic commit, turns out not
to pan out.