### PR TITLE
Use unique_ptr to prevent memory leaks in VideoDevice class

### DIFF
--- a/kms++util/inc/kms++util/videodevice.h
+++ b/kms++util/inc/kms++util/videodevice.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <memory>
 #include <kms++/kms++.h>
 
 class VideoStreamer;
@@ -50,8 +51,8 @@ private:
 	std::vector<kms::DumbFramebuffer*> m_capture_fbs;
 	std::vector<kms::DumbFramebuffer*> m_output_fbs;
 
-	VideoStreamer* m_capture_streamer;
-	VideoStreamer* m_output_streamer;
+	std::unique_ptr<VideoStreamer> m_capture_streamer;
+	std::unique_ptr<VideoStreamer> m_output_streamer;
 };
 
 class VideoStreamer

--- a/kms++util/src/videodevice.cpp
+++ b/kms++util/src/videodevice.cpp
@@ -246,7 +246,7 @@ VideoDevice::VideoDevice(const string& dev)
 }
 
 VideoDevice::VideoDevice(int fd)
-	: m_fd(fd), m_has_capture(false), m_has_output(false), m_has_m2m(false), m_capture_streamer(0), m_output_streamer(0)
+	: m_fd(fd), m_has_capture(false), m_has_output(false), m_has_m2m(false)
 {
 	if (fd < 0)
 		throw runtime_error("bad fd");
@@ -299,10 +299,10 @@ VideoStreamer* VideoDevice::get_capture_streamer()
 
 	if (!m_capture_streamer) {
 		auto type = m_has_mplane_capture ? VideoStreamer::StreamerType::CaptureMulti : VideoStreamer::StreamerType::CaptureSingle;
-		m_capture_streamer = new VideoStreamer(m_fd, type);
+		m_capture_streamer = std::unique_ptr<VideoStreamer>(new VideoStreamer(m_fd, type));
 	}
 
-	return m_capture_streamer;
+	return m_capture_streamer.get();
 }
 
 VideoStreamer* VideoDevice::get_output_streamer()
@@ -311,10 +311,10 @@ VideoStreamer* VideoDevice::get_output_streamer()
 
 	if (!m_output_streamer) {
 		auto type = m_has_mplane_output ? VideoStreamer::StreamerType::OutputMulti : VideoStreamer::StreamerType::OutputSingle;
-		m_output_streamer = new VideoStreamer(m_fd, type);
+		m_output_streamer = std::unique_ptr<VideoStreamer>(new VideoStreamer(m_fd, type));
 	}
 
-	return m_output_streamer;
+	return m_output_streamer.get();
 }
 
 vector<tuple<uint32_t, uint32_t>> VideoDevice::get_discrete_frame_sizes(PixelFormat fmt)


### PR DESCRIPTION
Looks like those VideoStreamer objects should be deleted by its owner, VideoDevice class.
Is that correct?
PTAL