### PR TITLE
added #include <string> to card.h to follow gcc10 porting guide

### DIFF
--- a/kms++/inc/kms++/card.h
+++ b/kms++/inc/kms++/card.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <map>
 #include <memory>
+#include <string>
 
 #include "decls.h"
 #include "pipeline.h"


### PR DESCRIPTION
Problem: card.h was missing the include for <string> so it could not be built with gcc 10.
Solution: added the missing include to card.h