### PR TITLE
Add partial fb flushing and expose some more properties in the python bindings

### DIFF
--- a/kms++/inc/kms++/framebuffer.h
+++ b/kms++/inc/kms++/framebuffer.h
@@ -41,6 +41,7 @@ public:
 	uint32_t width() const override { return m_width; }
 	uint32_t height() const override { return m_height; }
 
+	void flush(uint32_t x, uint32_t y, uint32_t width, uint32_t height);
 	void flush();
 
 protected:

--- a/kms++/src/framebuffer.cpp
+++ b/kms++/src/framebuffer.cpp
@@ -34,6 +34,17 @@ Framebuffer::Framebuffer(Card& card, uint32_t id)
 	card.m_framebuffers.push_back(this);
 }
 
+void Framebuffer::flush(uint32_t x, uint32_t y, uint32_t width, uint32_t height)
+{
+	drmModeClip clip{};
+	clip.x1 = x;
+	clip.y1 = y;
+	clip.x2 = x + width;
+	clip.y2 = y + height;
+
+	drmModeDirtyFB(card().fd(), id(), &clip, 1);
+}
+
 void Framebuffer::flush()
 {
 	drmModeClip clip{};

--- a/py/pykms/pykmsbase.cpp
+++ b/py/pykms/pykmsbase.cpp
@@ -148,6 +148,9 @@ void init_pykmsbase(py::module& m)
 		.def("offset", &Framebuffer::offset)
 		.def("fd", &Framebuffer::prime_fd)
 
+		.def("flush", (void (Framebuffer::*)(void)) & Framebuffer::flush)
+		.def("flush", (void (Framebuffer::*)(uint32_t x, uint32_t y, uint32_t width, uint32_t height)) & Framebuffer::flush)
+
 		// XXX pybind11 doesn't support a base object (DrmObject) with custom holder-type,
 		// and a subclass with standard holder-type.
 		// So we just copy the DrmObject members here.
@@ -161,6 +164,7 @@ void init_pykmsbase(py::module& m)
 		     py::keep_alive<1, 2>()) // Keep Card alive until this is destructed
 		.def(py::init<Card&, uint32_t, uint32_t, PixelFormat>(),
 		     py::keep_alive<1, 2>()) // Keep Card alive until this is destructed
+		.def("__repr__", [](const DumbFramebuffer& o) { return "<pykms.DumbFramebuffer " + to_string(o.id()) + ">"; })
 		;
 
 	py::class_<DmabufFramebuffer, Framebuffer>(m, "DmabufFramebuffer")
@@ -168,6 +172,7 @@ void init_pykmsbase(py::module& m)
 		     py::keep_alive<1, 2>()) // Keep Card alive until this is destructed
 		.def(py::init<Card&, uint32_t, uint32_t, PixelFormat, vector<int>, vector<uint32_t>, vector<uint32_t>>(),
 		     py::keep_alive<1, 2>()) // Keep Card alive until this is destructed
+		.def("__repr__", [](const DmabufFramebuffer& o) { return "<pykms.DmabufFramebuffer " + to_string(o.id()) + ">"; })
 		;
 
 	py::enum_<PixelFormat>(m, "PixelFormat")

--- a/py/pykms/pykmsbase.cpp
+++ b/py/pykms/pykmsbase.cpp
@@ -120,7 +120,20 @@ void init_pykmsbase(py::module& m)
 
 	py::class_<Property, DrmObject, unique_ptr<Property, py::nodelete>>(m, "Property")
 		.def_property_readonly("name", &Property::name)
-		.def_property_readonly("enums", &Property::get_enums);
+		.def_property_readonly("type", &Property::type)
+		.def_property_readonly("enums", &Property::get_enums)
+		.def_property_readonly("values", &Property::get_values)
+		.def("__repr__", [](const Property& o) { return "<pykms.Property " + to_string(o.id()) + " '" + o.name() + "'>"; })
+		;
+
+	py::enum_<PropertyType>(m, "PropertyType")
+		.value("Range", PropertyType::Range)
+		.value("Enum", PropertyType::Enum)
+		.value("Blob", PropertyType::Blob)
+		.value("Bitmask", PropertyType::Bitmask)
+		.value("Object", PropertyType::Object)
+		.value("SignedRange", PropertyType::SignedRange)
+		;
 
 	py::class_<Blob>(m, "Blob")
 		.def(py::init([](Card& card, py::buffer buf) {

--- a/py/pykms/pykmsbase.cpp
+++ b/py/pykms/pykmsbase.cpp
@@ -46,6 +46,10 @@ void init_pykmsbase(py::module& m)
 			return convert_vector(self->get_planes());
 		})
 
+		.def_property_readonly("properties", [](Card* self) {
+			return convert_vector(self->get_properties());
+		})
+
 		.def_property_readonly("has_atomic", &Card::has_atomic)
 		.def("get_prop", (Property * (Card::*)(uint32_t) const) & Card::get_prop)
 


### PR DESCRIPTION
I'm using kms++ to test my [drm/gud](https://elixir.bootlin.com/linux/latest/source/drivers/gpu/drm/gud) driver and needed partial flushing and some more property access from python.