### PR TITLE
Implement native visual matching for GBM kmscube

### DIFF
--- a/kmscube/cube-egl.h
+++ b/kmscube/cube-egl.h
@@ -6,16 +6,19 @@ class EglState
 {
 public:
 	EglState(void* native_display);
+	EglState(void* native_display, EGLint native_visual_id);
 	~EglState();
 
 	EGLDisplay display() const { return m_display; }
 	EGLConfig config() const { return m_config; }
 	EGLContext context() const { return m_context; }
+	EGLint native_visual_id() const { return m_native_visual_id; }
 
 private:
 	EGLDisplay m_display;
 	EGLConfig m_config;
 	EGLContext m_context;
+	EGLint m_native_visual_id;
 };
 
 class EglSurface

--- a/kmscube/cube-gbm.cpp
+++ b/kmscube/cube-gbm.cpp
@@ -48,10 +48,10 @@ private:
 class GbmSurface
 {
 public:
-	GbmSurface(GbmDevice& gdev, int width, int height)
+	GbmSurface(GbmDevice& gdev, int width, int height, uint32_t format)
 	{
 		m_surface = gbm_surface_create(gdev.handle(), width, height,
-					       GBM_FORMAT_XRGB8888,
+					       format,
 					       GBM_BO_USE_SCANOUT | GBM_BO_USE_RENDERING);
 		FAIL_IF(!m_surface, "failed to create gbm surface");
 	}
@@ -92,7 +92,7 @@ public:
 		: card(card), egl(egl), m_width(width), m_height(height),
 		  bo_prev(0), bo_next(0)
 	{
-		gsurface = unique_ptr<GbmSurface>(new GbmSurface(gdev, width, height));
+		gsurface = unique_ptr<GbmSurface>(new GbmSurface(gdev, width, height, egl.native_visual_id()));
 		esurface = eglCreateWindowSurface(egl.display(), egl.config(), gsurface->handle(), NULL);
 		FAIL_IF(esurface == EGL_NO_SURFACE, "failed to create egl surface");
 	}
@@ -314,7 +314,7 @@ void main_gbm()
 	FAIL_IF(!card.has_atomic(), "No atomic modesetting");
 
 	GbmDevice gdev(card);
-	EglState egl(gdev.handle());
+	EglState egl(gdev.handle(), GBM_FORMAT_XRGB8888);
 
 	ResourceManager resman(card);
 


### PR DESCRIPTION
Implement matching GBM buffer format to EGL NATIVE_VISUAL_ID. eglChooseConfig cannot match on NATIVE_VISUAL_ID, but GBM/EGL requires matching formats. Similar logic is implemented in kmscube code in match_config_to_visual.

X11, Wayland and Null cube demos remain unchanged.

Tested on Raspberry Pi-4 and VirtualBox/Ubuntu