### PR TITLE
make build work on debian bookworm

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,65 +1,68 @@
 project('kms++', 'cpp',
-    default_options : [
-        'cpp_std=c++20',
-    ],
-    version: '0.0.0',
+  default_options : ['cpp_std=c++20'],
+  version : '0.0.0',
 )
 
 cpp = meson.get_compiler('cpp')
-cpp_arguments = []
 
-if (cpp.get_id() == 'gcc' and
-    host_machine.cpu_family() == 'arm' and
-    cpp.has_argument('-Wno-psabi'))
-    cpp_arguments += [
-        '-Wno-psabi',
-    ]
+cpp_args = []
+cpp_defs = []
+
+host = host_machine
+
+# --- compiler warning flags ---
+if cpp.get_id() == 'gcc' and host.cpu_family() == 'arm' and cpp.has_argument('-Wno-psabi')
+  cpp_args += ['-Wno-psabi']
 endif
 
 if cpp.has_argument('-Wno-c99-designator')
-    cpp_arguments += [
-        '-Wno-c99-designator',
-    ]
+  cpp_args += ['-Wno-c99-designator']
 endif
 
-if cpp.compiles('#include <string>\n constexpr bool test(const std::string& x) { return x.empty(); }')
-    add_global_arguments('-DHAS_CONSTEXPR_STR', language : 'cpp')
+# --- feature detection ---
+if cpp.compiles('#include <string>\nconstexpr bool test(const std::string& x){ return x.empty(); }')
+  cpp_defs += ['-DHAS_CONSTEXPR_STR']
 else
-    message('Compiler does not support constexpr strings')
+  message('Compiler does not support constexpr strings')
 endif
 
-if cpp.compiles('#include <vector>\n constexpr bool test(const std::vector<int>& x) { return x.empty(); }')
-    add_global_arguments('-DHAS_CONSTEXPR_VEC', language : 'cpp')
+if cpp.compiles('#include <vector>\nconstexpr bool test(const std::vector<int>& x){ return x.empty(); }')
+  cpp_defs += ['-DHAS_CONSTEXPR_VEC']
 else
-    message('Compiler does not support constexpr vectors')
+  message('Compiler does not support constexpr vectors')
 endif
 
-add_project_arguments(cpp_arguments, language : 'cpp')
+# --- options ---
+if get_option('libutils')
+  cpp_defs += ['-DHAS_KMSXXUTIL']
+endif
+
+# NOTE: omap option handled via dependency(required: false)
+omap_opt = get_option('omap')
 
 libfmt_dep = dependency('fmt')
 
-libdrmomap_dep = dependency('libdrm_omap', required : get_option('omap'))
+libdrmomap_dep = dependency(
+  'libdrm_omap',
+  required : omap_opt,
+)
 
 if libdrmomap_dep.found()
-    add_global_arguments('-DHAS_LIBDRM_OMAP', language : 'cpp')
+  cpp_defs += ['-DHAS_LIBDRM_OMAP']
 endif
 
-if get_option('libutils')
-    add_global_arguments('-DHAS_KMSXXUTIL', language : 'cpp')
-endif
+# --- apply BEFORE subdirs (IMPORTANT) ---
+add_project_arguments(cpp_args + cpp_defs, language : 'cpp')
 
+# --- subprojects ---
 subdir('kms++')
 subdir('kms++util')
 subdir('utils')
 subdir('kmscube')
 subdir('py')
 
+# --- summary ---
 summary({
-            'omapdrm extensions (omap)': omapdrm_enabled,
-            'kms++utils library (libutils)': libutils_enabled,
-            'Python bindings (pykms)': pybindings_enabled,
-            'kmscube (kmscube)': kmscube_enabled,
-            'Utilities (utils)': utils_enabled,
-        },
-        section : 'Configuration',
-        bool_yn : true)
+  'omapdrm extensions (omap)': omap_opt.enabled(),
+  'kms++utils library (libutils)': get_option('libutils'),
+}, section : 'Configuration', bool_yn : true)


### PR DESCRIPTION
Not sure if maybe bookworm is actually using an older meson but i had problems with the current meson.build file when trying to run with `-Domap=disable` and the changes resolved this.